### PR TITLE
chore: Add `:logger` to `extra_applications`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule TinyMaps.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [extra_applications: [:logger]]
   end
 
   defp hex_package do


### PR DESCRIPTION
When generating a new mixfile this is the default behavior, and since Elixir `1.16.3` this [seems to](https://elixirforum.com/t/issues-running-mix-docs-undefinedfunctionerror-function-makeup-application/63707/9) cause `mix docs` to fail.