### PR TITLE
fix: Map renamed keys to strings

### DIFF
--- a/lib/tiny_maps.ex
+++ b/lib/tiny_maps.ex
@@ -147,6 +147,12 @@ defmodule TinyMaps do
             |> String.trim()
             |> expand_variable(modifier)
 
+          s =~ ~r/\A\s*#{@re_varname}\s*:\s*#{@re_varname}\s*\Z/ ->
+            s
+            |> String.trim()
+            |> String.split(":")
+            |> expand_kvp(modifier)
+
           true ->
             s
         end
@@ -155,6 +161,9 @@ defmodule TinyMaps do
 
     {:ok, result}
   end
+
+  defp expand_kvp([key, value], ?a), do: "#{key}: #{value}"
+  defp expand_kvp([key, value], ?s), do: "\"#{key}\" => #{value}"
 
   @doc false
   defp identify_entries(candidates, partial \\ "", acc \\ [])

--- a/test/tiny_maps_test.exs
+++ b/test/tiny_maps_test.exs
@@ -50,6 +50,13 @@ defmodule TinyMapsTest do
       assert %{"key_1" => "value_1", "key_2" => :val_2} = ~m{key_1, "key_2" => key_2_alt}
     end
 
+    test "atom key is converted to string" do
+      a = 1
+      b_alt = 3
+
+      assert %{"a" => 1, "atom_key" => 3} = ~m{a, atom_key: b_alt}
+    end
+
     test "raises on invalid varnames" do
       code = quote do: ~m{4asdf}
       assert_raise(SyntaxError, eval(code))


### PR DESCRIPTION
Resolves meyercm/shorter_maps#15

This fixes an oddity with the lowercase `~m` sigil where when manually adding a keyword key to the end the sigil, it is still an atom, rather than being a string key. 

I'm a bit mixed on this approach, since it seems a bit heavy-handed, with another match to look for keyword matches.