### PR TITLE
revert: Allow atom keys for `~m{}` sigil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING**: Fixed a longstanding "bug" where the `~m{}` sigil did not return string keys for key renames.
-
 ### Removed
-
-- Trademark sign previously shown after the project description in version
-  0.3.0
 
 ## [v3.0.0]
 

--- a/lib/tiny_maps.ex
+++ b/lib/tiny_maps.ex
@@ -191,12 +191,6 @@ defmodule TinyMaps do
             |> String.trim()
             |> expand_variable(modifier)
 
-          s =~ ~r/\A\s*#{@re_varname}\s*:\s*#{@re_varname}\s*\Z/ ->
-            s
-            |> String.trim()
-            |> String.split(":")
-            |> expand_kvp(modifier)
-
           true ->
             s
         end
@@ -205,9 +199,6 @@ defmodule TinyMaps do
 
     {:ok, result}
   end
-
-  defp expand_kvp([key, value], ?a), do: "#{key}: #{value}"
-  defp expand_kvp([key, value], ?s), do: "\"#{key}\" => #{value}"
 
   @doc false
   defp identify_entries(candidates, partial \\ "", acc \\ [])

--- a/test/tiny_maps_test.exs
+++ b/test/tiny_maps_test.exs
@@ -77,13 +77,6 @@ defmodule TinyMapsTest do
       assert %{"key_1" => "value_1", "key_2" => :val_2} = ~m{key_1, "key_2" => key_2_alt}
     end
 
-    test "atom key is converted to string" do
-      a = 1
-      b_alt = 3
-
-      assert %{"a" => 1, "atom_key" => 3} = ~m{a, atom_key: b_alt}
-    end
-
     test "raises on invalid varnames" do
       code = quote do: ~m{4asdf}
       assert_raise(SyntaxError, eval(code))


### PR DESCRIPTION
This reverts #10

I reconsidered #10 after merging it in and decided that I think the better developer experience here may actually be to keep the explicit atom key rather than converting it. The way I approached it previously makes it impossible to use TinyMaps and include an atom key in a `~m{}` sigil. I'm now leaning towards allowing that, and encouraging `~m{a, "b" => c}` if you need to rename a string key.